### PR TITLE
SEO-187452-mvc-Title-too-long/short

### DIFF
--- a/aspnetmvc/Rating/Overview.md
+++ b/aspnetmvc/Rating/Overview.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Rating | Rating | ASP.NET MVC | Syncfusion
-description: overview
+title: Overview of ASP.NET MVC Rating | Syncfusion
+description: Learn here about overview support in Syncfusion Essential ASP.NET MVC Rating control, its elements and more details.
 platform: ejmvc
 control: Rating
 documentation: ug
 ---
 
-# Rating
+# Overview of ASP.NET MVC Rating Control
 
 Essential Studio ASP.NET MVC Rating control provides an intuitive Rating experience that enables you to select a number of stars representing a Rating. You can configure the item size, orientation and the number of displayed items in the Rating control. You can also customize the Rating star image by using custom CSS.
 


### PR DESCRIPTION
Hi @Yvone-Atieno,

|Title|Description|
|--|--|
|Category|Title too long/short link |
|Hotfix PR|https://github.com/syncfusion-content/asp.netmvc-docs/pull/447|
|Task||
|Content Ticket||
|UX Ticket||

|Changes made|Reason for changes|
|--|--|
|Modify meta elements|For meta alignment with proper character count|

Regards,
Edith.