### PR TITLE
SEO-204825-Image-Alt-Missing-ASP.NET-MVC-Hotfix

### DIFF
--- a/aspnetmvc/MaskEdit/Behavior-Settings.md
+++ b/aspnetmvc/MaskEdit/Behavior-Settings.md
@@ -107,7 +107,7 @@ In the View page add MaskEditTextBox helper, and configure the Value property
 Output of MaskEditTextBox with the value property is as follows.
 
 
-![ASP.NET MVC Maskedit textbox with value in Define Value.](Behavior-Settings_images/Behavior-Settings_img6.png)
+![ASP.NET MVC Maskedit textbox with value in define value.](Behavior-Settings_images/Behavior-Settings_img6.png)
 
 MaskEditTextBox with value
 {:.caption}
@@ -235,7 +235,7 @@ MaskEdit with InputMode text
 
 
 
-![ASP.NET MVC Maskedit with ustom ccharacter.](Behavior-Settings_images/Behavior-Settings_img14.png)
+![ASP.NET MVC Maskedit with custom character.](Behavior-Settings_images/Behavior-Settings_img14.png)
 
 MaskEdit with CustomCharacter
 {:.caption}
@@ -382,7 +382,7 @@ In the View page use the corresponding MaskEdit helper for rendering MaskEdit co
 
 The output for Textboxes when TextAlign is set to “right”.
 
-![ASP.NET MVC Maskedit textbox with textAlign in appearance.](Behavior-Settings_images/Behavior-Settings_img18.png)
+![ASP.NET MVC Maskedit textbox with text align in appearance.](Behavior-Settings_images/Behavior-Settings_img18.png)
 
 MaskEditTextBox with textAlign
 {:.caption}


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha