### PR TITLE
SEO-206704-Multiple-H1 tag-ASP.Net MVC

### DIFF
--- a/aspnetmvc/Diagram/Gridlines.md
+++ b/aspnetmvc/Diagram/Gridlines.md
@@ -97,7 +97,7 @@ public ActionResult Index()
 
 ![](Gridlines_images/Gridlines_img2.png)
 
-# Snapping
+## Snapping
 
 ## Snap To Lines
 


### PR DESCRIPTION
itle | Description
-- | --
|Task Category |Multiple-H1-tag|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/206704|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BC1479F0A-9619-4A7C-B47E-C05E2DB08DD9%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|


Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it.|


Regards, 
Asha 