### PR TITLE
SEO-208087 ASP.NETMVC Multiple H1

### DIFF
--- a/aspnetmvc/Diagram/Gridlines.md
+++ b/aspnetmvc/Diagram/Gridlines.md
@@ -97,7 +97,7 @@ public ActionResult Index()
 
 ![](Gridlines_images/Gridlines_img2.png)
 
-# Snapping
+## Snapping
 
 ## Snap To Lines
 


### PR DESCRIPTION
Hi @Aishwarya-Ganesan,
 
|Title|Description|
|--|--|
|Task Category| Multiple H1|
|Content Task Link/Mail Screenshot||
|UX task| NA|
|Hotfix|https://github.com/syncfusion-content/blazor-docs/pull/6460
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/208087|
|Excel/SharePoint link|https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B5CF13BC9-37DF-4306-8DBB-F01D45C2C3B6%7D&file=Syncfusion%20domain.xlsx&action=default&mobileredirect=true|
 
|Changes made|Reason for changes|
|--|--|
|Multiple H1|According to SEO we should only have a single H1|
 
Regards,
Yvone.